### PR TITLE
Allow push/pop on full/empty queues to wait forever without bypassing GenServer timeouts

### DIFF
--- a/test/blocking_queue_test.exs
+++ b/test/blocking_queue_test.exs
@@ -66,6 +66,30 @@ defmodule BlockingQueueTest do
     assert input == BlockingQueue.pop_stream(pid) |> Enum.take(2)
   end
 
+  test "BlockingQueue pop on empty queue can wait beyond GenServer call timeout" do
+    {:ok, pid} = BlockingQueue.start_link(5)
+
+    task = Task.async(fn -> BlockingQueue.pop(pid, 5)end)
+    ref = Process.monitor(task.pid)
+
+    :timer.sleep 10
+    BlockingQueue.push pid, "Hello"
+    assert_receive {:DOWN, ^ref, :process, _, :normal}, 100
+  end
+
+  test "BlockingQueue push on full queue can wait beyond GenServer call timeout" do
+    {:ok, pid} = BlockingQueue.start_link(1)
+
+    BlockingQueue.push pid, "Hello"
+
+    task = Task.async(fn -> BlockingQueue.push(pid, "World", 5)end)
+    ref = Process.monitor(task.pid)
+
+    :timer.sleep 10
+    assert "Hello" == BlockingQueue.pop pid
+    assert_receive {:DOWN, ^ref, :process, _, :normal}, 100
+  end
+
   property "BlockingQueue supports async and blocking pushes and pops" do
     for_all xs in list(int) do
       implies length(xs) > 0 do


### PR DESCRIPTION
A couple of small things:
 - I don't know of a way to avoid adding the optional `timeout` args to `push/3` and `pop/2`, thus increasing their arities from 2 and 1 respectively. This was really only needed for the sake of writing the tests, but if there's a better way I'm all ears!
 - I couldn't seem to get `GenServer.reply`'s response to actually act as a `receive`able message in the client functions, so I had to rely on `case` statements and a conditional `receive` instead. This feels a bit wrong, but again, I'm not sure what a better approach might look like

Tests run much faster now, though. :-)