### PR TITLE
Handle multiple waiting poppers and pushers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /deps
 erl_crash.dump
 *.ez
+**/*.swp
+**/*.beam


### PR DESCRIPTION
A couple of notes on my thinking in this PR:
 - This should be a safe way to handle multiple waiters given that the client code only ever invokes GenServer.call, guaranteeing synchronous updates to the waiter lists for either push or pop
 - Clients waiting to pop don't need to be accommodated in any particular order, so using LIFO for performance reasons should be OK
 - Clients waiting to push should probably be handled in FIFO order so that we don't deviate from the normal push behavior of a non-full queue. Doing this has performance implications since List.last/1 and List.delete_at/2 are not particularly cheap operations. That said, I would hope there aren't 10's of thousands of waiting pushers at any given time, which will probably make the performance hit negligible